### PR TITLE
Fix: Resolve ModuleNotFoundError in campaign_logic.py

### DIFF
--- a/programmatic_simulator/backend/simulator/campaign_logic.py
+++ b/programmatic_simulator/backend/simulator/campaign_logic.py
@@ -1,7 +1,7 @@
 # programmatic_simulator/backend/simulator/campaign_logic.py
 import random
 import math
-from programmatic_simulator.backend.data import market_data
+from ..data import market_data
 
 # --- Constantes de Simulación y Puntuación ---
 COSTO_POR_MIL_IMPRESIONES_BASE = 10000  # COP


### PR DESCRIPTION
The application was failing to start due to a `ModuleNotFoundError` when `simulator/campaign_logic.py` attempted to import `programmatic_simulator.backend.data.market_data`.

This occurred because the import path was absolute and assumed `programmatic_simulator` was a top-level package accessible from the execution context of `campaign_logic.py`.

The fix changes the import statement in `programmatic_simulator/backend/simulator/campaign_logic.py` to use a relative import:

`from ..data import market_data`

This ensures that the `data` module is correctly located from within the `simulator` package, resolving the import error and allowing the Flask application to start.