### PR TITLE
Fix: Resolve ImportError in campaign_logic

### DIFF
--- a/programmatic_simulator/backend/simulator/campaign_logic.py
+++ b/programmatic_simulator/backend/simulator/campaign_logic.py
@@ -1,7 +1,7 @@
 # programmatic_simulator/backend/simulator/campaign_logic.py
 import random
 import math
-from ..data import market_data
+from data import market_data
 
 # --- Constantes de Simulación y Puntuación ---
 COSTO_POR_MIL_IMPRESIONES_BASE = 10000  # COP


### PR DESCRIPTION
Changed the relative import 'from ..data import market_data' to an absolute import 'from data import market_data' in programmatic_simulator/backend/simulator/campaign_logic.py.

This resolves an "ImportError: attempted relative import beyond top-level package" that occurred when running the Flask application. The change ensures that market_data is imported correctly based on the project's assumed PYTHONPATH when main.py is executed.