### PR TITLE
Fix: Correct relative import in campaign_logic.py

### DIFF
--- a/programmatic_simulator/backend/simulator/campaign_logic.py
+++ b/programmatic_simulator/backend/simulator/campaign_logic.py
@@ -1,7 +1,7 @@
 # programmatic_simulator/backend/simulator/campaign_logic.py
 import random
 import math
-from ..data import market_data
+from data import market_data
 
 # --- Constantes de Simulación y Puntuación ---
 COSTO_POR_MIL_IMPRESIONES_BASE = 12000  # COP


### PR DESCRIPTION
I changed the import for market_data in programmatic_simulator/backend/simulator/campaign_logic.py from a relative import (`from ..data import market_data`) to an absolute import (`from data import market_data`).

This resolves an ImportError that occurred because the relative import was attempting to go beyond the top-level package when the application was run via Flask.