### PR TITLE
feat: Implement dynamic audience size estimation and display

### DIFF
--- a/programmatic_simulator/frontend/css/style.css
+++ b/programmatic_simulator/frontend/css/style.css
@@ -103,3 +103,29 @@ hr {
 select option[value=""] {
     color: #888;
 }
+
+#estimatedAudienceSizeContainer {
+    background-color: #f0f9ff;
+    border: 1px solid #cce5ff;
+    padding: 10px;
+    margin-bottom: 20px;
+    border-radius: 5px;
+    text-align: center;
+}
+
+#estimatedAudienceDisplay {
+    font-weight: bold;
+}
+
+#audienceDescriptionContainer {
+    margin-top: 5px;
+    padding: 8px;
+    background-color: #e9ecef; /* A light grey background */
+    border-radius: 4px;
+    font-size: 0.9em;
+    color: #495057; /* Darker grey text */
+}
+
+.audience-description-text {
+    margin: 0;
+}

--- a/programmatic_simulator/frontend/index.html
+++ b/programmatic_simulator/frontend/index.html
@@ -11,6 +11,10 @@
     <div class="container">
         <h1>Simulador de Campañas Programáticas</h1>
 
+        <div id="estimatedAudienceSizeContainer">
+            <p>Estimated Targetable Audience: <span id="estimatedAudienceDisplay">N/A</span></p>
+        </div>
+
         <form id="campaignForm">
             <div class="form-group">
                 <label for="marca">Selecciona una Marca:</label>
@@ -24,6 +28,9 @@
                 <select id="audiencia" name="audiencia" required>
                     <option value="">Cargando audiencias...</option>
                 </select>
+                <div id="audienceDescriptionContainer">
+                    <p id="audienceDescriptionDisplay" class="audience-description-text">Select an audience to see its description.</p>
+                </div>
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
This commit introduces functionality to provide you with real-time estimates of your targetable audience size as you select different audiences and interests in the campaign simulator.

Key changes:

Backend:
- Added a new API endpoint `/api/estimate-audience-size` in `main.py`. This endpoint accepts an audience ID and selected interest IDs and returns potential and refined audience size estimates.
- Refactored `campaign_logic.py` to centralize audience size calculation (including population segment lookup and interest-based refinement) into a new `_calculate_audience_size_details` function.
- The main `simular_campana` function now uses this refactored logic, ensuring consistency and that campaign impressions are capped by the refined audience size.

Frontend:
- Added a new display area in `index.html` to show the "Estimated Targetable Audience," which updates dynamically.
- Added a display area for the selected audience's description, providing you with more context.
- Modified `app.js` to call the new backend endpoint when audience or interest selections change and to update the respective display areas.
- Added CSS for the new UI elements.

This addresses the issue of the frontend not fully reflecting backend market data capabilities, specifically concerning audience size and how interest selection impacts it. You can now see an immediate estimate of your audience reach before running the full simulation.