### PR TITLE
Fix: Explicitly serve index.html for the root path in Vercel

### DIFF
--- a/programmatic_simulator/vercel.json
+++ b/programmatic_simulator/vercel.json
@@ -1,0 +1,16 @@
+{
+  "routes": [
+    {
+      "src": "/",
+      "dest": "programmatic_simulator/frontend/index.html"
+    },
+    {
+      "src": "/api/(.*)",
+      "dest": "programmatic_simulator/backend/main.py"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "programmatic_simulator/frontend/$1"
+    }
+  ]
+}


### PR DESCRIPTION
I've added a specific route to `vercel.json` to ensure that `programmatic_simulator/frontend/index.html` is served when you navigate to the root URL. This resolves a 404 error that occurred in Vercel deployments where the implicit routing was not correctly serving the main page.