### PR TITLE
Fix backend imports when running main.py directly

### DIFF
--- a/programmatic_simulator/backend/main.py
+++ b/programmatic_simulator/backend/main.py
@@ -1,9 +1,15 @@
 # programmatic_simulator/backend/main.py
 import os
+import sys
 import logging
 import traceback
 from flask import Flask, request, jsonify
-from flask_cors import CORS # Importar CORS
+from flask_cors import CORS  # Importar CORS
+
+# Permitir ejecutar este archivo directamente sin usar "-m".
+if __package__ in (None, ""):
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+    __package__ = "programmatic_simulator.backend"
 from .simulator.campaign_logic import (
     simular_campana,
     _calculate_audience_size_details,


### PR DESCRIPTION
## Summary
- ensure the backend can be executed directly with `python programmatic_simulator/backend/main.py`
- update import path logic

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68541a491edc832b99b9292eb7aca51c