### PR TITLE
Add basic API tests

### DIFF
--- a/programmatic_simulator/backend/main.py
+++ b/programmatic_simulator/backend/main.py
@@ -1,9 +1,15 @@
 # programmatic_simulator/backend/main.py
 import os
+import sys
 import logging
 import traceback
 from flask import Flask, request, jsonify
-from flask_cors import CORS # Importar CORS
+from flask_cors import CORS  # Importar CORS
+
+# Permitir ejecutar este archivo directamente sin usar "-m".
+if __package__ in (None, ""):
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+    __package__ = "programmatic_simulator.backend"
 from .simulator.campaign_logic import (
     simular_campana,
     _calculate_audience_size_details,

--- a/programmatic_simulator/tests/backend/test_main_api.py
+++ b/programmatic_simulator/tests/backend/test_main_api.py
@@ -1,0 +1,24 @@
+import unittest
+from programmatic_simulator.backend.main import app
+
+class TestMainAPI(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+
+    def test_market_data(self):
+        resp = self.client.get('/api/market-data')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIn('marcas', data)
+        self.assertIn('audiencias', data)
+        self.assertIn('campaign_goals', data)
+
+    def test_interests_data(self):
+        resp = self.client.get('/api/interests-data')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIsInstance(data, list)
+        self.assertGreater(len(data), 0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests confirming `/api/market-data` and `/api/interests-data` return 200

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541a491edc832b99b9292eb7aca51c