### PR TITLE
Add Python requirements files

### DIFF
--- a/programmatic_simulator/backend/requirements.txt
+++ b/programmatic_simulator/backend/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-CORS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-CORS


### PR DESCRIPTION
## Summary
- add `requirements.txt` at project root
- add `requirements.txt` next to backend entrypoint so Vercel can install dependencies

## Testing
- `python -m pip install -r requirements.txt`
- `python -m unittest discover -s programmatic_simulator/tests/backend`


------
https://chatgpt.com/codex/tasks/task_e_68544b1f9430832b8da99bd2091ccc81