### PR TITLE
Enhance frontend with form reset feature

### DIFF
--- a/programmatic_simulator/frontend/css/style.css
+++ b/programmatic_simulator/frontend/css/style.css
@@ -51,6 +51,7 @@ body {
 
 #campaignSummaryContainer,
 button[type="submit"],
+#resetFormBtn,
 .results-container,
 #estimatedAudienceSizeContainer,
 #totalAffinityContainer {
@@ -129,6 +130,23 @@ button[type="submit"] {
 
 button[type="submit"]:hover {
     background-color: #0056b3;
+}
+
+#resetFormBtn {
+    background-color: #6c757d;
+    color: white;
+    padding: 12px 20px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+    width: 100%;
+    transition: background-color 0.3s ease;
+    margin-top: 5px;
+}
+
+#resetFormBtn:hover {
+    background-color: #5a6268;
 }
 
 .results-container {

--- a/programmatic_simulator/frontend/index.html
+++ b/programmatic_simulator/frontend/index.html
@@ -81,6 +81,7 @@
             </div>
 
             <button type="submit">Simular Campaña</button>
+            <button type="button" id="resetFormBtn">Limpiar Formulario</button>
         </form>
         </div>
         <div class="results-pane">

--- a/programmatic_simulator/frontend/js/app.js
+++ b/programmatic_simulator/frontend/js/app.js
@@ -20,6 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const fechaFinInput = document.getElementById('fechaFin');
     const campaignDurationDisplay = document.getElementById('campaignDurationDisplay');
     const totalCampaignBudgetDisplay = document.getElementById('totalCampaignBudgetDisplay');
+    const resetFormBtn = document.getElementById('resetFormBtn');
 
 
     let allAudiencesData = []; // Variable para almacenar datos de audiencias
@@ -771,6 +772,25 @@ document.addEventListener('DOMContentLoaded', () => {
         fechaFinInput.addEventListener('change', () => {
             updateCampaignSummary();
             updateFormAccess(); // Re-check access
+        });
+    }
+
+    if (resetFormBtn) {
+        resetFormBtn.addEventListener('click', () => {
+            campaignForm.reset();
+            productosSelect.innerHTML = '<option value="" disabled>Selecciona una marca primero...</option>';
+            productSelectionContainer.style.display = 'none';
+            clearInteresCheckboxes();
+            estimatedAudienceDisplay.textContent = 'N/A';
+            audienceSizeChangeIndicator.textContent = '';
+            audienceDescriptionDisplay.textContent = 'Select an audience to see its description.';
+            totalAffinityDisplay.textContent = 'N/A';
+            resultsContainer.style.display = 'none';
+            if (presupuestoValueDisplay) {
+                presupuestoValueDisplay.textContent = parseInt(presupuestoInput.value, 10).toLocaleString('es-CO');
+            }
+            updateCampaignSummary();
+            updateFormAccess();
         });
     }
 


### PR DESCRIPTION
## Summary
- add `Limpiar Formulario` button to reset the campaign form
- style new button in CSS and adjust layout
- hook up button logic in JS to clear selections and results

## Testing
- `python -m unittest discover -s programmatic_simulator/tests/backend -p 'test_*.py'`


------
https://chatgpt.com/codex/tasks/task_e_6854a4b6ad70832b872f7eea9f231aea