### PR TITLE
Add basic wizard flow

### DIFF
--- a/programmatic_simulator/frontend/css/style.css
+++ b/programmatic_simulator/frontend/css/style.css
@@ -32,6 +32,15 @@
     --font-family-base: sans-serif;
 }
 
+/* Wizard steps */
+.wizard-step {
+    display: none;
+}
+
+.wizard-step.active {
+    display: block;
+}
+
 /* Example dark theme */
 [data-theme="dark"] {
     --color-background: #1a1a1a;

--- a/programmatic_simulator/frontend/index.html
+++ b/programmatic_simulator/frontend/index.html
@@ -9,9 +9,10 @@
 </head>
 <body>
     <div class="container">
-        <h1>Simulador de Campañas Programáticas</h1>
-        <div class="layout">
-        <div class="controls">
+        <div id="stepConfig" class="wizard-step">
+            <h1>Simulador de Campañas Programáticas</h1>
+            <div class="layout">
+            <div class="controls">
         <div id="estimatedAudienceSizeContainer">
             <p>Estimated Targetable Audience: <span id="estimatedAudienceDisplay">N/A</span> <span id="audienceSizeChangeIndicator"></span></p>
         </div>
@@ -84,50 +85,52 @@
             <button type="button" id="resetFormBtn" class="btn btn-secondary">Limpiar Formulario</button>
         </form>
         </div>
-        <div class="results-pane">
-        <div id="resultsContainer" class="results-container" style="display:none;">
-            <h2>Resultados de la Simulación</h2>
-            <div class="summary">
-                <p><strong>Marca:</strong> <span id="resMarca"></span></p>
-                <p><strong>Audiencia:</strong> <span id="resAudiencia"></span></p>
-                <p><strong>Objetivo de Campaña:</strong> <span id="resCampaignGoal"></span></p>
-            </div>
-
-            <div class="metrics-dashboard">
-                <div class="metric-card" id="scoreCard">
-                    <div class="metric-title">Puntuación</div>
-                    <div class="metric-circle"><span id="resPuntuacion"></span></div>
-                </div>
-                <div class="metric-card" id="affinityCard">
-                    <div class="metric-title">Afinidad</div>
-                    <div class="metric-circle"><span id="resAfinidad"></span></div>
-                </div>
-                <div class="metric-card" id="impressionsCard">
-                    <div class="metric-title">Impresiones</div>
-                    <div class="metric-bar"><div class="metric-bar-fill" id="impressionsFill"></div></div>
-                    <div class="metric-number" id="resImpresiones"></div>
-                </div>
-                <div class="metric-card" id="ctrCard">
-                    <div class="metric-title">CTR</div>
-                    <div class="metric-bar"><div class="metric-bar-fill" id="ctrFill"></div></div>
-                    <div class="metric-number"><span id="resCTR"></span>%</div>
-                </div>
-                <div class="metric-card" id="budgetCard">
-                    <div class="metric-title">Presupuesto Gastado</div>
-                    <div class="metric-bar"><div class="metric-bar-fill" id="budgetFill"></div></div>
-                    <div class="metric-number" id="resPresupuestoGastado"></div>
-                </div>
-            </div>
-
-            <div id="detailedFeedbackSection" style="display:none; margin-top: 15px;">
-                <h4>Sugerencias y Comentarios Detallados:</h4>
-                <ul id="feedbackList" class="feedback-list">
-                    <!-- Feedback messages will be populated here by JavaScript -->
-                </ul>
-            </div>
-            <p><em><span id="resMensaje"></span></em></p>
         </div>
         </div>
+        <div id="stepResults" class="wizard-step" style="display:none;">
+            <h1>Resultados de la Simulación</h1>
+            <div id="resultsContainer" class="results-container">
+                <div class="summary">
+                    <p><strong>Marca:</strong> <span id="resMarca"></span></p>
+                    <p><strong>Audiencia:</strong> <span id="resAudiencia"></span></p>
+                    <p><strong>Objetivo de Campaña:</strong> <span id="resCampaignGoal"></span></p>
+                </div>
+
+                <div class="metrics-dashboard">
+                    <div class="metric-card" id="scoreCard">
+                        <div class="metric-title">Puntuación</div>
+                        <div class="metric-circle"><span id="resPuntuacion"></span></div>
+                    </div>
+                    <div class="metric-card" id="affinityCard">
+                        <div class="metric-title">Afinidad</div>
+                        <div class="metric-circle"><span id="resAfinidad"></span></div>
+                    </div>
+                    <div class="metric-card" id="impressionsCard">
+                        <div class="metric-title">Impresiones</div>
+                        <div class="metric-bar"><div class="metric-bar-fill" id="impressionsFill"></div></div>
+                        <div class="metric-number" id="resImpresiones"></div>
+                    </div>
+                    <div class="metric-card" id="ctrCard">
+                        <div class="metric-title">CTR</div>
+                        <div class="metric-bar"><div class="metric-bar-fill" id="ctrFill"></div></div>
+                        <div class="metric-number"><span id="resCTR"></span>%</div>
+                    </div>
+                    <div class="metric-card" id="budgetCard">
+                        <div class="metric-title">Presupuesto Gastado</div>
+                        <div class="metric-bar"><div class="metric-bar-fill" id="budgetFill"></div></div>
+                        <div class="metric-number" id="resPresupuestoGastado"></div>
+                    </div>
+                </div>
+
+                <div id="detailedFeedbackSection" style="display:none; margin-top: 15px;">
+                    <h4>Sugerencias y Comentarios Detallados:</h4>
+                    <ul id="feedbackList" class="feedback-list">
+                        <!-- Feedback messages will be populated here by JavaScript -->
+                    </ul>
+                </div>
+                <p><em><span id="resMensaje"></span></em></p>
+                <button type="button" id="backToConfigBtn" class="btn btn-secondary">Volver a Configuración</button>
+            </div>
         </div>
     </div>
 

--- a/programmatic_simulator/frontend/js/app.js
+++ b/programmatic_simulator/frontend/js/app.js
@@ -21,11 +21,27 @@ document.addEventListener('DOMContentLoaded', () => {
     const campaignDurationDisplay = document.getElementById('campaignDurationDisplay');
     const totalCampaignBudgetDisplay = document.getElementById('totalCampaignBudgetDisplay');
     const resetFormBtn = document.getElementById('resetFormBtn');
+    const stepConfig = document.getElementById('stepConfig');
+    const stepResults = document.getElementById('stepResults');
+    const backToConfigBtn = document.getElementById('backToConfigBtn');
 
 
     let allAudiencesData = []; // Variable para almacenar datos de audiencias
     let allBrandsData = []; // Variable para almacenar datos de marcas con sus productos
     let previousAudienceSize = null; // Variable to store the previous audience size
+
+    function showConfigStep() {
+        if (stepConfig) stepConfig.classList.add('active');
+        if (stepResults) stepResults.classList.remove('active');
+    }
+
+    function showResultsStep() {
+        if (stepConfig) stepConfig.classList.remove('active');
+        if (stepResults) stepResults.classList.add('active');
+    }
+
+    // Ensure initial state
+    showConfigStep();
 
     // Actualizado para coincidir con los nuevos campos en index.html
     const originalResultsHTML = `
@@ -201,13 +217,14 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             const data = await response.json();
-            // Pass dailyInvestment and duration to displayResults or make them accessible globally/scoped
             displayResults(data, dailyInvestmentFromForm, durationFromForm);
+            showResultsStep();
 
         } catch (error) {
             console.error('Error al simular campaña:', error);
             // Pass null or undefined for extra params if error occurs before they are set
             displayResults({ error: error.message || "No se pudo conectar con el servidor de simulación." }, dailyInvestmentFromForm, durationFromForm);
+            showResultsStep();
         }
     });
 
@@ -800,6 +817,13 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             updateCampaignSummary();
             updateFormAccess();
+            showConfigStep();
+        });
+    }
+
+    if (backToConfigBtn) {
+        backToConfigBtn.addEventListener('click', () => {
+            showConfigStep();
         });
     }
 


### PR DESCRIPTION
## Summary
- add wizard step styles
- split configuration and results into sequential wizard steps
- toggle steps in JS and support back button

## Testing
- `python -m unittest discover -s programmatic_simulator/tests/backend -p "test_*.py"` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6855c3dd4480832ba925f94c040683fc