### PR TITLE
Fix results screen not showing

### DIFF
--- a/programmatic_simulator/frontend/index.html
+++ b/programmatic_simulator/frontend/index.html
@@ -87,7 +87,7 @@
         </div>
         </div>
         </div>
-        <div id="stepResults" class="wizard-step" style="display:none;">
+        <div id="stepResults" class="wizard-step">
             <h1>Resultados de la Simulación</h1>
             <div id="resultsContainer" class="results-container">
                 <div class="summary">


### PR DESCRIPTION
## Summary
- ensure the results step can be shown by removing inline `display:none`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855c94e8f04832b9305357c4a608bd3